### PR TITLE
Add custom request headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -318,6 +318,14 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 	return
 }
 
+func (cl *Client) HTTPCustomHeaders(req *http.Request) error {
+	err := cl.config.HTTPCustomHeaders(req)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (cl *Client) AddDhtServer(d DhtServer) {
 	cl.dhtServers = append(cl.dhtServers, d)
 }

--- a/client.go
+++ b/client.go
@@ -318,14 +318,6 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 	return
 }
 
-func (cl *Client) HTTPCustomHeaders(req *http.Request) error {
-	err := cl.config.HTTPCustomHeaders(req)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (cl *Client) AddDhtServer(d DhtServer) {
 	cl.dhtServers = append(cl.dhtServers, d)
 }

--- a/config.go
+++ b/config.go
@@ -102,6 +102,9 @@ type ClientConfig struct {
 	LookupTrackerIp func(*url.URL) ([]net.IP, error)
 	// HTTPUserAgent changes default UserAgent for HTTP requests
 	HTTPUserAgent string
+	// HTTPCustomHeaders adds custom headers to the request before it's sent.
+	// Useful for adding authentication for use with a private tracker.
+	HTTPCustomHeaders func(*http.Request) error
 	// Updated occasionally to when there's been some changes to client
 	// behaviour in case other clients are assuming anything of us. See also
 	// `bep20`.

--- a/config.go
+++ b/config.go
@@ -102,9 +102,9 @@ type ClientConfig struct {
 	LookupTrackerIp func(*url.URL) ([]net.IP, error)
 	// HTTPUserAgent changes default UserAgent for HTTP requests
 	HTTPUserAgent string
-	// HTTPCustomHeaders adds custom headers to the request before it's sent.
-	// Useful for adding authentication for use with a private tracker.
-	HTTPCustomHeaders func(*http.Request) error
+	// HTTPRequestDirector modifies the request before it's sent.
+	// Useful for adding authentication headers, for example
+	HTTPRequestDirector func(*http.Request) error
 	// Updated occasionally to when there's been some changes to client
 	// behaviour in case other clients are assuming anything of us. See also
 	// `bep20`.

--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -99,7 +99,7 @@ func (cl Client) Announce(ctx context.Context, ar AnnounceRequest, opt AnnounceO
 
 	err = opt.HTTPRequestDirector(req)
 	if err != nil {
-		err = fmt.Errorf("error applying custom HTTP request headers: %s", err)
+		err = fmt.Errorf("error modifying HTTP request: %s", err)
 		return
 	}
 

--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -95,6 +95,11 @@ func (cl Client) Announce(ctx context.Context, ar AnnounceRequest, opt AnnounceO
 	if userAgent != "" {
 		req.Header.Set("User-Agent", userAgent)
 	}
+
+	fmt.Println("announcing with options", opt)
+	// err = opt.HTTPCustomHeaders(req)
+	req.Header.Add("testing-header", "header 1") // TEST
+
 	req.Host = opt.HostHeader
 	resp, err := cl.hc.Do(req)
 	if err != nil {

--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -97,10 +97,12 @@ func (cl Client) Announce(ctx context.Context, ar AnnounceRequest, opt AnnounceO
 		req.Header.Set("User-Agent", userAgent)
 	}
 
-	err = opt.HTTPRequestDirector(req)
-	if err != nil {
-		err = fmt.Errorf("error modifying HTTP request: %s", err)
-		return
+	if opt.HTTPRequestDirector != nil {
+		err = opt.HTTPRequestDirector(req)
+		if err != nil {
+			err = fmt.Errorf("error modifying HTTP request: %s", err)
+			return
+		}
 	}
 
 	req.Host = opt.HostHeader

--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -98,6 +98,10 @@ func (cl Client) Announce(ctx context.Context, ar AnnounceRequest, opt AnnounceO
 	}
 
 	err = opt.HTTPCustomHeaders(req)
+	if err != nil {
+		err = fmt.Errorf("error applying custom HTTP request headers: %s", err)
+		return
+	}
 
 	req.Host = opt.HostHeader
 	resp, err := cl.hc.Do(req)

--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -76,11 +76,11 @@ func setAnnounceParams(_url *url.URL, ar *AnnounceRequest, opts AnnounceOpt) {
 }
 
 type AnnounceOpt struct {
-	UserAgent         string
-	HostHeader        string
-	ClientIp4         net.IP
-	ClientIp6         net.IP
-	HTTPCustomHeaders func(*http.Request) error
+	UserAgent           string
+	HostHeader          string
+	ClientIp4           net.IP
+	ClientIp6           net.IP
+	HTTPRequestDirector func(*http.Request) error
 }
 
 type AnnounceRequest = udp.AnnounceRequest
@@ -97,7 +97,7 @@ func (cl Client) Announce(ctx context.Context, ar AnnounceRequest, opt AnnounceO
 		req.Header.Set("User-Agent", userAgent)
 	}
 
-	err = opt.HTTPCustomHeaders(req)
+	err = opt.HTTPRequestDirector(req)
 	if err != nil {
 		err = fmt.Errorf("error applying custom HTTP request headers: %s", err)
 		return

--- a/tracker/http/http.go
+++ b/tracker/http/http.go
@@ -76,10 +76,11 @@ func setAnnounceParams(_url *url.URL, ar *AnnounceRequest, opts AnnounceOpt) {
 }
 
 type AnnounceOpt struct {
-	UserAgent  string
-	HostHeader string
-	ClientIp4  net.IP
-	ClientIp6  net.IP
+	UserAgent         string
+	HostHeader        string
+	ClientIp4         net.IP
+	ClientIp6         net.IP
+	HTTPCustomHeaders func(*http.Request) error
 }
 
 type AnnounceRequest = udp.AnnounceRequest
@@ -96,9 +97,7 @@ func (cl Client) Announce(ctx context.Context, ar AnnounceRequest, opt AnnounceO
 		req.Header.Set("User-Agent", userAgent)
 	}
 
-	fmt.Println("announcing with options", opt)
-	// err = opt.HTTPCustomHeaders(req)
-	req.Header.Add("testing-header", "header 1") // TEST
+	err = opt.HTTPCustomHeaders(req)
 
 	req.Host = opt.HostHeader
 	resp, err := cl.hc.Do(req)

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -35,16 +35,16 @@ type AnnounceEvent = udp.AnnounceEvent
 var ErrBadScheme = errors.New("unknown scheme")
 
 type Announce struct {
-	TrackerUrl        string
-	Request           AnnounceRequest
-	HostHeader        string
-	HTTPProxy         func(*http.Request) (*url.URL, error)
-	HTTPCustomHeaders func(*http.Request) error
-	DialContext       func(ctx context.Context, network, addr string) (net.Conn, error)
-	ListenPacket      func(network, addr string) (net.PacketConn, error)
-	ServerName        string
-	UserAgent         string
-	UdpNetwork        string
+	TrackerUrl          string
+	Request             AnnounceRequest
+	HostHeader          string
+	HTTPProxy           func(*http.Request) (*url.URL, error)
+	HTTPRequestDirector func(*http.Request) error
+	DialContext         func(ctx context.Context, network, addr string) (net.Conn, error)
+	ListenPacket        func(network, addr string) (net.PacketConn, error)
+	ServerName          string
+	UserAgent           string
+	UdpNetwork          string
 	// If the port is zero, it's assumed to be the same as the Request.Port.
 	ClientIp4 krpc.NodeAddr
 	// If the port is zero, it's assumed to be the same as the Request.Port.
@@ -80,10 +80,10 @@ func (me Announce) Do() (res AnnounceResponse, err error) {
 		me.Context = ctx
 	}
 	return cl.Announce(me.Context, me.Request, trHttp.AnnounceOpt{
-		UserAgent:         me.UserAgent,
-		HostHeader:        me.HostHeader,
-		ClientIp4:         me.ClientIp4.IP,
-		ClientIp6:         me.ClientIp6.IP,
-		HTTPCustomHeaders: me.HTTPCustomHeaders,
+		UserAgent:           me.UserAgent,
+		HostHeader:          me.HostHeader,
+		ClientIp4:           me.ClientIp4.IP,
+		ClientIp6:           me.ClientIp6.IP,
+		HTTPRequestDirector: me.HTTPRequestDirector,
 	})
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -35,15 +35,16 @@ type AnnounceEvent = udp.AnnounceEvent
 var ErrBadScheme = errors.New("unknown scheme")
 
 type Announce struct {
-	TrackerUrl   string
-	Request      AnnounceRequest
-	HostHeader   string
-	HTTPProxy    func(*http.Request) (*url.URL, error)
-	DialContext  func(ctx context.Context, network, addr string) (net.Conn, error)
-	ListenPacket func(network, addr string) (net.PacketConn, error)
-	ServerName   string
-	UserAgent    string
-	UdpNetwork   string
+	TrackerUrl        string
+	Request           AnnounceRequest
+	HostHeader        string
+	HTTPProxy         func(*http.Request) (*url.URL, error)
+	HTTPCustomHeaders func(*http.Request) error
+	DialContext       func(ctx context.Context, network, addr string) (net.Conn, error)
+	ListenPacket      func(network, addr string) (net.PacketConn, error)
+	ServerName        string
+	UserAgent         string
+	UdpNetwork        string
 	// If the port is zero, it's assumed to be the same as the Request.Port.
 	ClientIp4 krpc.NodeAddr
 	// If the port is zero, it's assumed to be the same as the Request.Port.
@@ -79,9 +80,10 @@ func (me Announce) Do() (res AnnounceResponse, err error) {
 		me.Context = ctx
 	}
 	return cl.Announce(me.Context, me.Request, trHttp.AnnounceOpt{
-		UserAgent:  me.UserAgent,
-		HostHeader: me.HostHeader,
-		ClientIp4:  me.ClientIp4.IP,
-		ClientIp6:  me.ClientIp6.IP,
+		UserAgent:         me.UserAgent,
+		HostHeader:        me.HostHeader,
+		ClientIp4:         me.ClientIp4.IP,
+		ClientIp6:         me.ClientIp6.IP,
+		HTTPCustomHeaders: me.HTTPCustomHeaders,
 	})
 }

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -156,19 +156,20 @@ func (me *trackerScraper) announce(ctx context.Context, event tracker.AnnounceEv
 	defer cancel()
 	me.t.logger.WithDefaultLevel(log.Debug).Printf("announcing to %q: %#v", me.u.String(), req)
 	res, err := tracker.Announce{
-		Context:      ctx,
-		HTTPProxy:    me.t.cl.config.HTTPProxy,
-		DialContext:  me.t.cl.config.TrackerDialContext,
-		ListenPacket: me.t.cl.config.TrackerListenPacket,
-		UserAgent:    me.t.cl.config.HTTPUserAgent,
-		TrackerUrl:   me.trackerUrl(ip),
-		Request:      req,
-		HostHeader:   me.u.Host,
-		ServerName:   me.u.Hostname(),
-		UdpNetwork:   me.u.Scheme,
-		ClientIp4:    krpc.NodeAddr{IP: me.t.cl.config.PublicIp4},
-		ClientIp6:    krpc.NodeAddr{IP: me.t.cl.config.PublicIp6},
-		Logger:       me.t.logger,
+		Context:           ctx,
+		HTTPProxy:         me.t.cl.config.HTTPProxy,
+		HTTPCustomHeaders: me.t.cl.config.HTTPCustomHeaders,
+		DialContext:       me.t.cl.config.TrackerDialContext,
+		ListenPacket:      me.t.cl.config.TrackerListenPacket,
+		UserAgent:         me.t.cl.config.HTTPUserAgent,
+		TrackerUrl:        me.trackerUrl(ip),
+		Request:           req,
+		HostHeader:        me.u.Host,
+		ServerName:        me.u.Hostname(),
+		UdpNetwork:        me.u.Scheme,
+		ClientIp4:         krpc.NodeAddr{IP: me.t.cl.config.PublicIp4},
+		ClientIp6:         krpc.NodeAddr{IP: me.t.cl.config.PublicIp6},
+		Logger:            me.t.logger,
 	}.Do()
 	me.t.logger.WithDefaultLevel(log.Debug).Printf("announce to %q returned %#v: %v", me.u.String(), res, err)
 	if err != nil {

--- a/tracker_scraper.go
+++ b/tracker_scraper.go
@@ -156,20 +156,20 @@ func (me *trackerScraper) announce(ctx context.Context, event tracker.AnnounceEv
 	defer cancel()
 	me.t.logger.WithDefaultLevel(log.Debug).Printf("announcing to %q: %#v", me.u.String(), req)
 	res, err := tracker.Announce{
-		Context:           ctx,
-		HTTPProxy:         me.t.cl.config.HTTPProxy,
-		HTTPCustomHeaders: me.t.cl.config.HTTPCustomHeaders,
-		DialContext:       me.t.cl.config.TrackerDialContext,
-		ListenPacket:      me.t.cl.config.TrackerListenPacket,
-		UserAgent:         me.t.cl.config.HTTPUserAgent,
-		TrackerUrl:        me.trackerUrl(ip),
-		Request:           req,
-		HostHeader:        me.u.Host,
-		ServerName:        me.u.Hostname(),
-		UdpNetwork:        me.u.Scheme,
-		ClientIp4:         krpc.NodeAddr{IP: me.t.cl.config.PublicIp4},
-		ClientIp6:         krpc.NodeAddr{IP: me.t.cl.config.PublicIp6},
-		Logger:            me.t.logger,
+		Context:             ctx,
+		HTTPProxy:           me.t.cl.config.HTTPProxy,
+		HTTPRequestDirector: me.t.cl.config.HTTPRequestDirector,
+		DialContext:         me.t.cl.config.TrackerDialContext,
+		ListenPacket:        me.t.cl.config.TrackerListenPacket,
+		UserAgent:           me.t.cl.config.HTTPUserAgent,
+		TrackerUrl:          me.trackerUrl(ip),
+		Request:             req,
+		HostHeader:          me.u.Host,
+		ServerName:          me.u.Hostname(),
+		UdpNetwork:          me.u.Scheme,
+		ClientIp4:           krpc.NodeAddr{IP: me.t.cl.config.PublicIp4},
+		ClientIp6:           krpc.NodeAddr{IP: me.t.cl.config.PublicIp6},
+		Logger:              me.t.logger,
 	}.Do()
 	me.t.logger.WithDefaultLevel(log.Debug).Printf("announce to %q returned %#v: %v", me.u.String(), res, err)
 	if err != nil {


### PR DESCRIPTION
Add custom headers to HTTP requests to be used, for example, for authentication with private trackers.