### PR TITLE
Add WebRTC peer connection transport stats

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -2993,16 +2993,15 @@ func (t *Torrent) iterUndirtiedRequestIndexesInPiece(
 	)
 }
 
-type webRtcStatsReports []webrtc.StatsReport
+type webRtcStatsReports map[string]webrtc.StatsReport
 
 func (t *Torrent) GetWebRtcPeerConnStats() map[string]webRtcStatsReports {
 	stats := make(map[string]webRtcStatsReports)
 	trackersMap := t.cl.websocketTrackers.clients
 	for i, trackerClient := range trackersMap {
-		ts := trackerClient.TransportStats()
+		ts := trackerClient.RtcPeerConnStats()
 		stats[i] = ts
 	}
-
 	return stats
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -32,7 +32,7 @@ import (
 	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
 	"github.com/pion/datachannel"
-	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v4"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 

--- a/torrent.go
+++ b/torrent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
@@ -2990,6 +2991,19 @@ func (t *Torrent) iterUndirtiedRequestIndexesInPiece(
 		pieceRequestIndexOffset, pieceRequestIndexOffset+t.pieceNumChunks(piece),
 		f,
 	)
+}
+
+type webRtcStatsReports []webrtc.StatsReport
+
+func (t *Torrent) GetWebRtcPeerConnStats() map[string]webRtcStatsReports {
+	stats := make(map[string]webRtcStatsReports)
+	trackersMap := t.cl.websocketTrackers.clients
+	for i, trackerClient := range trackersMap {
+		ts := trackerClient.TransportStats()
+		stats[i] = ts
+	}
+
+	return stats
 }
 
 type requestState struct {

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -277,7 +277,7 @@ func (tc *TrackerClient) Announce(event tracker.AnnounceEvent, infoHash [20]byte
 	}
 
 	// save the leecher peer connections
-	tc.storePeerConnection(offerIDBinary, pc)
+	tc.storePeerConnection(fmt.Sprintf("%x", randOfferId[:]), pc)
 
 	pc.OnClose(func() {
 		delete(tc.rtcPeerConns, offerIDBinary)
@@ -439,7 +439,7 @@ func (tc *TrackerClient) handleOffer(
 	}
 
 	// save the seeder peer connections
-	tc.storePeerConnection(offerContext.Id, peerConnection)
+	tc.storePeerConnection(fmt.Sprintf("%x", offerContext.Id[:]), peerConnection)
 
 	response := AnnounceResponse{
 		Action:   "announce",

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -278,9 +278,6 @@ func (tc *TrackerClient) Announce(event tracker.AnnounceEvent, infoHash [20]byte
 
 	pc.OnClose(func() {
 		stats := pc.GetStats()
-		if tc.transportStats == nil {
-			tc.transportStats = []webrtc.StatsReport{}
-		}
 		tc.transportStats = append(tc.transportStats, stats)
 	})
 


### PR DESCRIPTION
Looks like there is still some timing issue, whereby `tc.transportStats` is `null` if the file transfer is too short (small file on same machine, for example).
For larger file transfers, there is a high variability in the number of peer connections being created during the transfer (i.e. `len(tc.transportStats)`). Is this real or again a timing issue when appending new stats to the slice?

Still in draft for now.