### PR TITLE
Enable credentials for ICE Servers access

### DIFF
--- a/client.go
+++ b/client.go
@@ -296,6 +296,14 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 	if cl.config.Observers != nil {
 		obs = &cl.config.Observers.Trackers
 	}
+
+	var ICEServers []webrtc.ICEServer
+	if cl.config.ICEServerList != nil {
+		ICEServers = cl.config.ICEServerList
+	} else if cl.config.ICEServers != nil {
+		ICEServers = []webrtc.ICEServer{{URLs: cl.config.ICEServers}}
+	}
+
 	cl.websocketTrackers = websocketTrackers{
 		obs:    obs,
 		PeerId: cl.peerID,
@@ -311,7 +319,7 @@ func NewClient(cfg *ClientConfig) (cl *Client, err error) {
 		},
 		Proxy:                      cl.config.HTTPProxy,
 		WebsocketTrackerHttpHeader: cl.config.WebsocketTrackerHttpHeader,
-		ICEServers:                 cl.config.ICEServers,
+		ICEServers:                 ICEServers,
 		DialContext:                cl.config.TrackerDialContext,
 		OnConn: func(dc datachannel.ReadWriteCloser, dcc webtorrent.DataChannelContext) {
 			cl.lock()
@@ -1806,7 +1814,13 @@ func (cl *Client) String() string {
 }
 
 func (cl *Client) ICEServers() []webrtc.ICEServer {
-	return cl.config.ICEServers
+	var ICEServers []webrtc.ICEServer
+	if cl.config.ICEServerList != nil {
+		ICEServers = cl.config.ICEServerList
+	} else if cl.config.ICEServers != nil {
+		ICEServers = []webrtc.ICEServer{{URLs: cl.config.ICEServers}}
+	}
+	return ICEServers
 }
 
 // Returns connection-level aggregate connStats at the Client level. See the comment on

--- a/client.go
+++ b/client.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dustin/go-humanize"
 	gbtree "github.com/google/btree"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/internal/check"
@@ -1804,7 +1805,7 @@ func (cl *Client) String() string {
 	return fmt.Sprintf("<%[1]T %[1]p>", cl)
 }
 
-func (cl *Client) ICEServers() []string {
+func (cl *Client) ICEServers() []webrtc.ICEServer {
 	return cl.config.ICEServers
 }
 

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/anacrolix/torrent/webtorrent"
+	"github.com/pion/webrtc/v3"
 
 	"github.com/anacrolix/dht/v2"
 	"github.com/anacrolix/dht/v2/krpc"
@@ -205,7 +206,7 @@ type ClientConfig struct {
 
 	// ICEServers defines a slice describing servers available to be used by
 	// ICE, such as STUN and TURN servers.
-	ICEServers []string
+	ICEServers []webrtc.ICEServer
 
 	DialRateLimiter *rate.Limiter
 

--- a/config.go
+++ b/config.go
@@ -204,9 +204,13 @@ type ClientConfig struct {
 
 	Callbacks Callbacks
 
-	// ICEServers defines a slice describing servers available to be used by
+	// ICEServerList defines a slice describing servers available to be used by
 	// ICE, such as STUN and TURN servers.
-	ICEServers []webrtc.ICEServer
+	ICEServerList []webrtc.ICEServer
+
+	// Legacy support. ICEServers does not support server authentication and therefore
+	// it cannot be used with most TURN servers. Use ICEServerList instead.
+	ICEServers []string
 
 	DialRateLimiter *rate.Limiter
 

--- a/webtorrent/tracker-client.go
+++ b/webtorrent/tracker-client.go
@@ -5,10 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/anacrolix/torrent/types/infohash"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/anacrolix/torrent/types/infohash"
 
 	g "github.com/anacrolix/generics"
 	"github.com/anacrolix/log"
@@ -62,7 +63,7 @@ type TrackerClient struct {
 	pingTicker     *time.Ticker
 
 	WebsocketTrackerHttpHeader func() http.Header
-	ICEServers                 []string
+	ICEServers                 []webrtc.ICEServer
 }
 
 func (me *TrackerClient) Stats() TrackerClientStats {

--- a/webtorrent/transport.go
+++ b/webtorrent/transport.go
@@ -48,12 +48,12 @@ func (me *wrappedPeerConnection) Close() error {
 	return err
 }
 
-func newPeerConnection(logger log.Logger, iceServers []string) (*wrappedPeerConnection, error) {
+func newPeerConnection(logger log.Logger, iceServers []webrtc.ICEServer) (*wrappedPeerConnection, error) {
 	newPeerConnectionMu.Lock()
 	defer newPeerConnectionMu.Unlock()
 	ctx, span := otel.Tracer(tracerName).Start(context.Background(), "PeerConnection")
 
-	pcConfig := webrtc.Configuration{ICEServers: []webrtc.ICEServer{{URLs: iceServers}}}
+	pcConfig := webrtc.Configuration{ICEServers: iceServers}
 
 	pc, err := api.NewPeerConnection(pcConfig)
 	if err != nil {

--- a/wstracker.go
+++ b/wstracker.go
@@ -3,15 +3,17 @@ package torrent
 import (
 	"context"
 	"fmt"
-	"github.com/anacrolix/torrent/webtorrent"
 	"net"
 	netHttp "net/http"
 	"net/url"
 	"sync"
 
+	"github.com/anacrolix/torrent/webtorrent"
+
 	"github.com/anacrolix/log"
 	"github.com/gorilla/websocket"
 	"github.com/pion/datachannel"
+	"github.com/pion/webrtc/v3"
 
 	"github.com/anacrolix/torrent/tracker"
 	httpTracker "github.com/anacrolix/torrent/tracker/http"
@@ -46,7 +48,7 @@ type websocketTrackers struct {
 	Proxy                      httpTracker.ProxyFunc
 	DialContext                func(ctx context.Context, network, addr string) (net.Conn, error)
 	WebsocketTrackerHttpHeader func() netHttp.Header
-	ICEServers                 []string
+	ICEServers                 []webrtc.ICEServer
 }
 
 func (me *websocketTrackers) Get(url string, infoHash [20]byte) (*webtorrent.TrackerClient, func()) {


### PR DESCRIPTION
This allows specifying credentials for access to ICE servers, in particular TURN servers.